### PR TITLE
build: update on_master.yml

### DIFF
--- a/.github/workflows/on_master.yml
+++ b/.github/workflows/on_master.yml
@@ -11,7 +11,7 @@ jobs:
     name: Update Notion property
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install
         run: npm ci
       - name: Build
@@ -31,7 +31,7 @@ jobs:
           force: true
       - name: Bump version and push tag
         id: version
-        uses: anothrNick/github-tag-action@1.35.0
+        uses: anothrNick/github-tag-action@1.62.0
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           WITH_V: false


### PR DESCRIPTION
This PR updates 2 actions to the latest versions to fix the deprecation of node12 and the deprecation of set-output.

- actions/checkout v2 to v3
-  anothrNick/github-tag-action v1.35.0 to 1.62.0
